### PR TITLE
Improve error handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2021"
 rusoto_core = "0.47.0"
 rusoto_s3 = "0.47.0"
 tokio = {version = "1.15.0", features = ["full"] }
-thiserror = "1.0.30"
-rand = "0.8.4"
 
 [lib]
 name = "s3_fs"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -54,7 +54,7 @@ impl FS {
         Ok(dir_name.to_string())
     }
 
-    fn ensure_paths_exists(path: &S3Path) -> anyhow::Result<bool, S3PathError> {
+    fn ensure_paths_exists(path: &S3Path) -> Result<bool, S3PathError> {
         path.try_exists()
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,8 @@
+use crate::errors::S3PathError;
 use crate::s3::S3Path;
 use crate::services::S3Service;
 
+#[derive(Debug)]
 struct FS {
     pub path: S3Path,
     service: S3Service,
@@ -25,37 +27,34 @@ impl FS {
         FS { path, service }
     }
 
-    pub fn copy<P>(&self, to: P) -> Result<Option<i64>, ()>
+    pub fn copy<P>(&self, to: P) -> Result<Option<i64>, S3PathError>
     where
         P: ToString + Copy,
     {
-        let from_content = self.service.get_object_body().unwrap();
+        let from_content = self.service.get_object_body()?;
 
-        let from_metadata = self.path.metadata().unwrap();
+        let from_metadata = self.path.metadata()?;
 
-        match self.service.write_to_object(
+        self.service.write_to_object(
             from_metadata.content_length,
             from_content,
             to,
             self.path.metadata().unwrap().metadata,
-        ) {
-            Ok(_) => Ok(from_metadata.content_length),
-            Err(_) => Err(()),
-        }
+        )?;
+
+        Ok(from_metadata.content_length)
     }
 
-    pub fn create_dir(&self, path: &S3Path) -> Result<String, ()> {
+    pub fn create_dir(&self, path: &S3Path) -> Result<String, S3PathError> {
         let dir_name = path.path.to_str().unwrap();
-        match self
-            .service
-            .write_to_object(None, None, self.service.bucket.key.to_string(), None)
-        {
-            Ok(_) => Ok(dir_name.to_string()),
-            Err(_) => Err(()),
-        }
+
+        self.service
+            .write_to_object(None, None, self.service.bucket.key.to_string(), None)?;
+
+        Ok(dir_name.to_string())
     }
 
-    fn ensure_paths_exists(path: &S3Path) -> Result<bool, ()> {
+    fn ensure_paths_exists(path: &S3Path) -> anyhow::Result<bool, S3PathError> {
         path.try_exists()
     }
 }
@@ -82,7 +81,7 @@ impl FS {
 ///
 /// Panics if anything goes wrong when making the PutObject call.
 #[allow(clippy::result_unit_err)]
-pub fn copy<P>(from: S3Path, to: P) -> Result<Option<i64>, ()>
+pub fn copy<P>(from: S3Path, to: P) -> Result<Option<i64>, S3PathError>
 where
     P: ToString + Copy,
 {
@@ -114,11 +113,42 @@ where
 ///
 /// Panics if anything goes wrong when making the PutObject call.
 #[allow(clippy::result_unit_err)]
-pub fn create_dir<P>(path: P) -> Result<String, ()>
+pub fn create_dir<P>(path: P) -> Result<String, S3PathError>
 where
     P: ToString + Copy,
 {
     let fs = FS::from_string(path);
 
     fs.create_dir(&fs.path)
+}
+
+/// Recursively create a directory and all of its parent components if they are missing.
+///
+///
+/// # Example
+///
+/// ```no_run
+/// use s3_fs::fs;
+/// use s3_fs::s3::S3Path;
+/// fs::create_dir_all(
+///         "foo/some_dir/bar/",
+///     );
+///
+/// S3Path::new("foo/some_dir/").try_exists();
+/// S3Path::new("foo/some/bar/").try_exists();
+/// ```
+///
+/// # Panics
+///
+/// Panics if anything goes wrong when making the PutObject call.
+#[allow(clippy::result_unit_err)]
+pub fn create_dir_all<P>(path: P)
+where
+    P: ToString + Copy,
+{
+    let fs = FS::from_string(path);
+
+    dbg!(&fs.path.path.components());
+
+    // fs.create_dir(&fs.path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod bucket;
-mod errors;
+pub mod errors;
 pub mod fs;
 mod object;
 pub mod s3;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,5 @@
 use s3_fs::fs;
-use s3_fs::s3::S3Path;
 
 fn main() {
-    let s3_path = S3Path::new("/ola-testing-model-registry/dir/data_source/inner_inner/test.txt");
-    fs::copy(s3_path, "dir/data_source/inner_inner/new_copy.txt").unwrap();
-
-    let copied_path =
-        S3Path::new("/ola-testing-model-registry/dir/data_source/inner_inner/new_copy.txt");
-    dbg!(&copied_path.exists());
-
-    // fs::create_dir("/ola-testing-model-registry/dir/data_source/inner_inner/ICreatedYou").unwrap();
+    fs::create_dir_all("/foo/bar");
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,4 +1,5 @@
 use crate::bucket::BucketConfig;
+use crate::errors::S3PathError;
 use crate::object::{ObjectMetadata, S3ObjectType};
 use crate::services::S3Service;
 use rusoto_s3::S3Client;
@@ -102,7 +103,7 @@ impl S3Path {
     ///
     ///
     #[allow(clippy::result_unit_err)]
-    pub fn try_exists(&self) -> Result<bool, ()> {
+    pub fn try_exists(&self) -> Result<bool, S3PathError> {
         self.service.ensure_object_exists()
     }
 
@@ -147,11 +148,8 @@ impl S3Path {
     ///   s3_path.metadata();
     ///
     ///```
-    pub fn metadata(&self) -> Option<ObjectMetadata> {
-        match self.exists() {
-            true => Some(self.service.get_object_metadata().unwrap()),
-            false => None,
-        }
+    pub fn metadata(&self) -> Result<ObjectMetadata, S3PathError> {
+        self.service.get_object_metadata()
     }
 
     fn validate_path(path: &Path) {


### PR DESCRIPTION
Decided to change the error handling a bit because a lot of things can go wrong when making the call to S3. Every method now returns a result of type `<T, S3PathError>` where `T` can be anything.